### PR TITLE
add support for string annotations

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,9 @@
+Contributing
+============
+
+Contributions to spype are welcome. 
+
+If you find a problem, would like to propose a change, or have a question, use the `issue tracker <https://github.com/d-chambers/spype/issues>`_.
+
+I will be making some rather rapid changes until version 0.1.0, after which I more or less plan to follow the `obspy branching model <https://github.com/obspy/obspy/wiki/ObsPy-Git-Branching-Model>`_. Basically, if you want to fix a bug use branch "maintenance_version" where version is the last released version. If you want to add a new feature just branch off master. 
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 spype
-======================================
+=====
 
 Spype is a [s]imple [py]thon [p]ipelin[e] library.
 
@@ -25,7 +25,7 @@ Liscence: BSD
 
 WARNING: spype is brand new and experimental, dont use it in production until it matures a little, and expect frequent API changes.
 
-Contents:
+Documentation:
 
 .. toctree::
    :maxdepth: 1
@@ -39,9 +39,11 @@ Contents:
 
    notebooks/tutorial.ipynb
 
+   contributing.rst
+
 
 API
-======================================
+===
 .. toctree::
    :maxdepth: 1
 

--- a/spype/__init__.py
+++ b/spype/__init__.py
@@ -8,6 +8,7 @@ from spype.core.pype import Pype
 from spype.utils import context
 from spype.version import __version__
 from spype.exceptions import ExitTask
+from spype.types import signature
 
 from spype.constants import PYPE_FIXTURES, TASK_FIXTURES
 


### PR DESCRIPTION
This PR allows spype's type functions to work with annotations defined as string types. 
For example, the valid type annotation on `func` would not have worked with type checking before:

```python
class SomeClass:
    pass

def func(a: 'SomeClass') -> 'SomeClass':
    return a
```
but it should work fine now.